### PR TITLE
Fixing Issue in IE mobile

### DIFF
--- a/ngStorage.js
+++ b/ngStorage.js
@@ -67,17 +67,19 @@
                 _last$storage = angular.copy($storage);
 
                 $rootScope.$watch(function() {
+                    var temp$storage;
                     _debounce || (_debounce = setTimeout(function() {
                         _debounce = null;
 
                         if (!angular.equals($storage, _last$storage)) {
+                            temp$storage = angular.copy(_last$storage);
                             angular.forEach($storage, function(v, k) {
                                 angular.isDefined(v) && '$' !== k[0] && webStorage.setItem('ngStorage-' + k, angular.toJson(v));
 
-                                delete _last$storage[k];
+                                delete temp$storage[k];
                             });
 
-                            for (var k in _last$storage) {
+                            for (var k in temp$storage) {
                                 webStorage.removeItem('ngStorage-' + k);
                             }
 


### PR DESCRIPTION
When you call `webStorage.setItem` it fires off the 'storage' event handler.  This causes the `_last$storage` variable to be set during the `forEach` loop.  When the item is finally removed from `webStorage` the `_last$storage` variable will be incorrect.